### PR TITLE
fix: error "cannot access local variable" initialize the variable befor the for loop

### DIFF
--- a/zatca_erpgulf/zatca_erpgulf/schedule_pos.py
+++ b/zatca_erpgulf/zatca_erpgulf/schedule_pos.py
@@ -43,6 +43,7 @@ def submit_posinvoices_to_zatca_background_process():
             ],
         )
         # print(f"companies: {companies}", "ZATCA Background Job")
+        any_company_in_range = False
         for company in companies:
             start_time = None
             end_time = None


### PR DESCRIPTION
This pull request introduces a minor change in the `submit_posinvoices_to_zatca_background_process` function within the `zatca_erpgulf/schedule_pos.py` file. The variable, `any_company_in_range`, has been added to avoid the error: "cannot access local variable" that is always found in the error log

![image](https://github.com/user-attachments/assets/60aedcad-5b4b-47ed-b703-d2a0edf5b47b)
