### PR TITLE
Improve error message for invalid ZATCA VAT category to clarify item-level source

### DIFF
--- a/zatca_erpgulf/zatca_erpgulf/createxml.py
+++ b/zatca_erpgulf/zatca_erpgulf/createxml.py
@@ -942,8 +942,10 @@ def add_document_level_discount_with_tax_template(invoice, sales_invoice_doc):
             cbc_id.text = "O"
         else:
             frappe.throw(
-                "Invalid VAT category code. Must be one of 'Standard', 'Zero Rated', 'Exempted', "
-                "or 'Services outside scope of tax / Not subject to VAT'."
+                "Invalid or missing ZATCA VAT category in the Item Tax Template " 
+                "linked to Sales Invoice Item. Ensure each Item Tax Template " 
+                "includes one of the following categories: "
+                "'Standard', 'Zero Rated', 'Exempted', or 'Services outside scope of tax / Not subject to VAT'."
             )
 
         cbc_percent = ET.SubElement(cac_tax_category, "cbc:Percent")

--- a/zatca_erpgulf/zatca_erpgulf/posxml.py
+++ b/zatca_erpgulf/zatca_erpgulf/posxml.py
@@ -831,8 +831,10 @@ def add_document_level_discount_with_tax_template(invoice, pos_invoice_doc):
             cbc_id.text = "O"
         else:
             frappe.throw(
-                "Invalid VAT category code. Must be one of 'Standard', 'Zero Rated', 'Exempted', "
-                "or 'Services outside scope of tax / Not subject to VAT'."
+                "Invalid or missing ZATCA VAT category in the Item Tax Template " 
+                "linked to Sales Invoice Item. Ensure each Item Tax Template " 
+                "includes one of the following categories: "
+                "'Standard', 'Zero Rated', 'Exempted', or 'Services outside scope of tax / Not subject to VAT'."
             )
 
         cbc_percent = ET.SubElement(cac_taxcategory, "cbc:Percent")


### PR DESCRIPTION
This PR updates the error message shown when an invalid ZATCA VAT category code is detected during invoice validation.

Previously, the message stated:
Invalid VAT category code. Must be one of 'Standard', 'Zero Rated', 'Exempted', or 'Services outside scope of tax / Not subject to VAT'.

Issue:
The message was ambiguous — users typically check the main custom_zatca_tax_category field on the Sales Invoice (parent), assuming that’s what the validation uses.
However, the system actually retrieves the VAT category from the Item Tax Template linked to each Sales Invoice Item.

Fix:
The updated message clarifies that the validation occurs at the item level and the value is pulled from each item's linked Item Tax Template.

This should help users more quickly identify and correct missing or invalid category values without confusion.