### PR TITLE
fix: detect item_wise_tax_details instead of pinning to v16

### DIFF
--- a/zatca_erpgulf/zatca_erpgulf/create_xml_final_part.py
+++ b/zatca_erpgulf/zatca_erpgulf/create_xml_final_part.py
@@ -10,12 +10,12 @@ from datetime import datetime
 from frappe.utils.data import get_time
 from decimal import Decimal, ROUND_HALF_UP
 import frappe
-import json
 from frappe import _
 from zatca_erpgulf.zatca_erpgulf.xml_tax_data import (
     get_tax_for_item,
     get_exemption_reason_map,
 )
+from zatca_erpgulf.zatca_erpgulf.utils import get_tax_wise_detail
 
 
 ITEM_TAX_TEMPLATE = "Item Tax Template"
@@ -612,20 +612,6 @@ def add_line_item_discount(cac_price, single_item, sales_invoice_doc):
     except (ValueError, KeyError, AttributeError) as error:
         frappe.throw(_(f"Error occurred while adding line item discount: {str(error)}"))
         return None
-
-def get_tax_wise_detail(sales_invoice_doc,single_item):
-    """getting item wise tax"""
-    if int(frappe.__version__.split(".", 1)[0]) == 16 and sales_invoice_doc.item_wise_tax_details:
-                tax_rate = float(f"{sales_invoice_doc.item_wise_tax_details[0].rate:.1f}")
-                tax_amount = sales_invoice_doc.item_wise_tax_details[0].amount
-
-                # build JSON exactly like v15
-                tax_json = json.dumps({
-                    single_item.item_code: [tax_rate, float(tax_amount)]
-                })
-    else:
-        tax_json = sales_invoice_doc.taxes[0].item_wise_tax_detail
-    return tax_json
 
 def item_data(invoice, sales_invoice_doc):
     """

--- a/zatca_erpgulf/zatca_erpgulf/pos_final.py
+++ b/zatca_erpgulf/zatca_erpgulf/pos_final.py
@@ -14,12 +14,12 @@ import xml.etree.ElementTree as ET
 from xml.dom import minidom
 from frappe import _
 import frappe
-import json
 from zatca_erpgulf.zatca_erpgulf.posxml import (
     get_exemption_reason_map,
     get_tax_for_item,
     add_line_item_discount,
 )
+from zatca_erpgulf.zatca_erpgulf.utils import get_tax_wise_detail
 
 
 ITEM_TAX_TEMPLATE = "Item Tax Template"
@@ -271,20 +271,6 @@ def tax_data_with_template(invoice, pos_invoice_doc):
     except (AttributeError, KeyError, ValueError, TypeError) as e:
         frappe.throw(_(f"Data processing error in tax data with template: {str(e)}"))
 
-
-def get_tax_wise_detail(pos_invoice_doc,single_item):
-    """getting item wise tax"""
-    if int(frappe.__version__.split(".", 1)[0]) == 16 and pos_invoice_doc.item_wise_tax_details:
-        tax_rate = float(f"{pos_invoice_doc.item_wise_tax_details[0].rate:.1f}")
-        tax_amount = pos_invoice_doc.item_wise_tax_details[0].amount
-
-        # build JSON exactly like v15
-        tax_json = json.dumps({
-            single_item.item_code: [tax_rate, float(tax_amount)]
-        })
-    else:
-        tax_json = pos_invoice_doc.taxes[0].item_wise_tax_detail
-    return tax_json
 
 def item_data(invoice, pos_invoice_doc):
     """Function for item data"""

--- a/zatca_erpgulf/zatca_erpgulf/posxml.py
+++ b/zatca_erpgulf/zatca_erpgulf/posxml.py
@@ -17,6 +17,7 @@ import json
 from frappe.utils.data import get_time
 from frappe import _
 import frappe
+from zatca_erpgulf.zatca_erpgulf.utils import get_tax_wise_detail
 
 
 def get_tax_for_item(full_string, item):
@@ -934,20 +935,6 @@ def get_exemption_reason_map():
             "Not subject to VAT"
         ),
     }
-
-def get_tax_wise_detail(pos_invoice_doc,single_item):
-    """getting item wise tax"""
-    if int(frappe.__version__.split(".", 1)[0]) == 16 and pos_invoice_doc.item_wise_tax_details:
-        tax_rate = float(f"{pos_invoice_doc.item_wise_tax_details[0].rate:.1f}")
-        tax_amount = pos_invoice_doc.item_wise_tax_details[0].amount
-
-        # build JSON exactly like v15
-        tax_json = json.dumps({
-            single_item.item_code: [tax_rate, float(tax_amount)]
-        })
-    else:
-        tax_json = pos_invoice_doc.taxes[0].item_wise_tax_detail
-    return tax_json 
 
 def get_tax_total_from_items(pos_invoice_doc):
     """function for get tax total from items"""

--- a/zatca_erpgulf/zatca_erpgulf/utils.py
+++ b/zatca_erpgulf/zatca_erpgulf/utils.py
@@ -1,3 +1,4 @@
+import json
 from decimal import Decimal, ROUND_HALF_UP
 from num2words import num2words
 
@@ -92,3 +93,25 @@ def generate_qr_for_doc(doctype, docname, url, file_field=None):
         url=url,
         file_field=file_field
     )
+
+
+def get_tax_wise_detail(invoice_doc, single_item):
+    """Return item-wise tax as the legacy JSON string, on any ERPNext version.
+
+    ERPNext moved item-wise tax from the `item_wise_tax_detail` JSON field on
+    Sales Taxes and Charges to the `item_wise_tax_details` child table on the
+    invoice. Detect the child table instead of pinning to a version number.
+    """
+    if invoice_doc.meta.has_field("item_wise_tax_details"):
+        rows = invoice_doc.get("item_wise_tax_details")
+        if rows:
+            tax_rate = float(f"{rows[0].rate:.1f}")
+            tax_amount = rows[0].amount
+
+            # build JSON exactly like v15
+            return json.dumps({single_item.item_code: [tax_rate, float(tax_amount)]})
+
+        # No child rows: fall back to the legacy field if this version still has it.
+        return invoice_doc.taxes[0].get("item_wise_tax_detail") or "{}"
+
+    return invoice_doc.taxes[0].item_wise_tax_detail

--- a/zatca_erpgulf/zatca_erpgulf/xml_tax_data.py
+++ b/zatca_erpgulf/zatca_erpgulf/xml_tax_data.py
@@ -9,6 +9,7 @@ from frappe import _
 import frappe
 import json
 from decimal import Decimal, ROUND_HALF_UP
+from zatca_erpgulf.zatca_erpgulf.utils import get_tax_wise_detail
 
 TAX_CALCULATION_ERROR = "Tax Calculation Error"
 CAC_TAX_TOTAL = "cac:TaxTotal"
@@ -68,20 +69,6 @@ def get_tax_for_item(full_string, item):
     except TypeError as e:
         frappe.throw(_("Type error occurred in tax for item: " + str(e)))
         return None
-
-def get_tax_wise_detail(sales_invoice_doc,single_item):
-    """getting item wise tax"""
-    if int(frappe.__version__.split(".", 1)[0]) == 16 and sales_invoice_doc.item_wise_tax_details:
-        tax_rate = float(f"{sales_invoice_doc.item_wise_tax_details[0].rate:.1f}")
-        tax_amount = sales_invoice_doc.item_wise_tax_details[0].amount
-
-        # build JSON exactly like v15
-        tax_json = json.dumps({
-            single_item.item_code: [tax_rate, float(tax_amount)]
-        })
-    else:
-        tax_json = sales_invoice_doc.taxes[0].item_wise_tax_detail
-    return tax_json
 
 def get_tax_total_from_items(sales_invoice_doc):
     """Getting tax total for items"""


### PR DESCRIPTION
Submitting an invoice on a bench running frappe/erpnext develop failed with:

    AttributeError in get_tax_total_from_items:
    'SalesTaxesandCharges' object has no attribute 'item_wise_tax_detail'

ERPNext moved item-wise tax data off the `item_wise_tax_detail` JSON field on Sales Taxes and Charges and onto the `item_wise_tax_details` child table on the invoice. `get_tax_wise_detail` gated that on an exact version match:

    if int(frappe.__version__.split(".", 1)[0]) == 16 and ...

On develop (frappe and erpnext are both 17.0.0-dev) the gate is False, so the code falls through to the removed field and raises. Since `develop` always carries the next major's -dev version, an `== 16` check breaks again on every future major.

Detect the child table instead, matching what ERPNext does internally in `ignore_item_wise_tax_details` (erpnext/controllers/taxes_and_totals.py), which tests `doc.meta.get_field("item_wise_tax_details")` rather than a version number. Behaviour is unchanged on v15 (no child field -> legacy path) and on v16 (child table present and populated -> same logic as before); on v17 the removed field is no longer touched.

The helper existed as four verbatim copies, so it moves to utils.py and the call sites in xml_tax_data, create_xml_final_part, posxml and pos_final now import it. `json` became unused in create_xml_final_part and pos_final.