### PR TITLE
Fix three failures on invoices with advances, and guard the compliance call

### DIFF
--- a/zatca_erpgulf/zatca_erpgulf/create_xml_final_part.py
+++ b/zatca_erpgulf/zatca_erpgulf/create_xml_final_part.py
@@ -1326,15 +1326,19 @@ def item_data_with_template_advance_invoice(invoice, sales_invoice_doc):
 
                     tax_cat = ET.SubElement(subtotal, "cac:TaxCategory")
                     zatca_tax_category = item_tax_template.custom_zatca_tax_category
-                    if zatca_tax_category == "Standard":
-                        cbc_id_12.text = "S"
-                    elif zatca_tax_category == ZERO_RATED:
-                        cbc_id_12.text = "Z"
-                    elif zatca_tax_category == "Exempted":
-                        cbc_id_12.text = "E"
-                    elif zatca_tax_category == OUTSIDE_SCOPE:
-                        cbc_id_12.text = "O"
-                    ET.SubElement(tax_cat, "cbc:ID").text = cbc_id_12.text
+                    # Hold the category code in a local. This used to assign it to
+                    # cbc_id_12, which is not a category element at all: it is the
+                    # cac:TaxScheme/cbc:ID of the *last standard invoice line*,
+                    # created and set to "VAT" at the top of this function. Writing
+                    # "S" into it retroactively corrupted that already-built line,
+                    # leaving <cac:TaxScheme><cbc:ID>S</cbc:ID></cac:TaxScheme>
+                    # where "VAT" belongs. A ClassifiedTaxCategory is only
+                    # identifiable as a VAT category through that scheme id, so the
+                    # standard line lost its BT-151 and ZATCA rejected the invoice
+                    # with BR-CO-04 ("Each Invoice line shall be categorized with an
+                    # Invoiced item VAT category code").
+                    advance_tax_code = get_tax_code(zatca_tax_category)
+                    ET.SubElement(tax_cat, "cbc:ID").text = advance_tax_code
                     ET.SubElement(tax_cat, "cbc:Percent").text = (
                         f"{float(item_tax_percentage):.2f}"
                     )
@@ -1349,7 +1353,7 @@ def item_data_with_template_advance_invoice(invoice, sales_invoice_doc):
                     tax_cat_adv = ET.SubElement(
                         item_tag_adv, "cac:ClassifiedTaxCategory"
                     )
-                    ET.SubElement(tax_cat_adv, "cbc:ID").text = cbc_id_12.text
+                    ET.SubElement(tax_cat_adv, "cbc:ID").text = advance_tax_code
                     ET.SubElement(tax_cat_adv, "cbc:Percent").text = (
                         f"{float(item_tax_percentage):.2f}"
                     )

--- a/zatca_erpgulf/zatca_erpgulf/create_xml_final_part.py
+++ b/zatca_erpgulf/zatca_erpgulf/create_xml_final_part.py
@@ -813,6 +813,12 @@ def item_data_advance_invoice(invoice, sales_invoice_doc):
     try:
         qty = "cbc:BaseQuantity"
 
+        # Default for the advance block further down, which used to read whatever
+        # this loop left behind - describing the advance line with the LAST
+        # standard item's rate, and raising NameError outright on an invoice with
+        # no standard lines.
+        item_tax_percentage = 15
+
         # Add regular item lines
         for single_item in sales_invoice_doc.items:
             tax_json = get_tax_wise_detail(sales_invoice_doc,single_item)
@@ -909,6 +915,16 @@ def item_data_advance_invoice(invoice, sales_invoice_doc):
             advance_invoice = frappe.get_doc("Advance Sales Invoice", reference_name)
 
             for i, single_item in enumerate(advance_invoice.custom_item):
+                # Prefer the advance item's own tax template where it has one.
+                adv_percentage = item_tax_percentage
+                if single_item.get("item_tax_template"):
+                    adv_template = frappe.get_doc(
+                        ITEM_TAX_TEMPLATE, single_item.item_tax_template
+                    )
+                    adv_percentage = (
+                        adv_template.taxes[0].tax_rate if adv_template.taxes else 15
+                    )
+
                 line = ET.SubElement(invoice, "cac:InvoiceLine")
                 ET.SubElement(line, "cbc:ID").text = str(
                     len(sales_invoice_doc.items) + i + 1
@@ -952,7 +968,7 @@ def item_data_advance_invoice(invoice, sales_invoice_doc):
                 ET.SubElement(
                     subtotal, "cbc:TaxAmount", currencyID=sales_invoice_doc.currency
                 ).text = str(
-                    abs(round(single_item.amount * item_tax_percentage / 100, 2))
+                    abs(round(single_item.amount * adv_percentage / 100, 2))
                 )
 
                 tax_cat = ET.SubElement(subtotal, "cac:TaxCategory")
@@ -960,7 +976,7 @@ def item_data_advance_invoice(invoice, sales_invoice_doc):
                     sales_invoice_doc.custom_zatca_tax_category
                 )
                 ET.SubElement(tax_cat, "cbc:Percent").text = (
-                    f"{float(item_tax_percentage):.2f}"
+                    f"{float(adv_percentage):.2f}"
                 )
                 ET.SubElement(
                     ET.SubElement(tax_cat, "cac:TaxScheme"), "cbc:ID"
@@ -976,7 +992,7 @@ def item_data_advance_invoice(invoice, sales_invoice_doc):
                     sales_invoice_doc.custom_zatca_tax_category
                 )
                 ET.SubElement(tax_cat_item, "cbc:Percent").text = (
-                    f"{float(item_tax_percentage):.2f}"
+                    f"{float(adv_percentage):.2f}"
                 )
                 ET.SubElement(
                     ET.SubElement(tax_cat_item, "cac:TaxScheme"), "cbc:ID"
@@ -1148,6 +1164,14 @@ def item_data_with_template_advance_invoice(invoice, sales_invoice_doc):
     try:
         qty = "cbc:BaseQuantity"
 
+        # Defaults for the advance block further down. It used to read whatever
+        # this loop happened to leave behind in item_tax_template /
+        # item_tax_percentage, which meant an advance line was described by the
+        # LAST standard item's tax template rather than its own, and a Sales
+        # Invoice with no standard lines raised NameError before reaching ZATCA.
+        item_tax_percentage = 15
+        item_tax_template = None
+
         for single_item in sales_invoice_doc.items:
             item_tax_template = frappe.get_doc(
                 ITEM_TAX_TEMPLATE, single_item.item_tax_template
@@ -1256,6 +1280,29 @@ def item_data_with_template_advance_invoice(invoice, sales_invoice_doc):
                     "Advance Sales Invoice", reference_name
                 )
                 for i, single_item in enumerate(advance_invoice.custom_item):
+                    # Describe the advance line from its OWN item tax template
+                    # where it has one, falling back to the invoice-level values
+                    # for advances created before that field existed.
+                    adv_template = None
+                    if single_item.get("item_tax_template"):
+                        adv_template = frappe.get_doc(
+                            ITEM_TAX_TEMPLATE, single_item.item_tax_template
+                        )
+                    if adv_template:
+                        adv_percentage = (
+                            adv_template.taxes[0].tax_rate
+                            if adv_template.taxes
+                            else 15
+                        )
+                        adv_category = adv_template.custom_zatca_tax_category
+                    else:
+                        adv_percentage = item_tax_percentage
+                        adv_category = (
+                            item_tax_template.custom_zatca_tax_category
+                            if item_tax_template
+                            else sales_invoice_doc.custom_zatca_tax_category
+                        )
+
                     adv_line = ET.SubElement(invoice, "cac:InvoiceLine")
                     ET.SubElement(adv_line, "cbc:ID").text = str(advance_line_id + i)
                     ET.SubElement(
@@ -1321,11 +1368,11 @@ def item_data_with_template_advance_invoice(invoice, sales_invoice_doc):
                     ET.SubElement(
                         subtotal, "cbc:TaxAmount", currencyID=sales_invoice_doc.currency
                     ).text = str(
-                        abs(round(single_item.amount * item_tax_percentage / 100, 2))
+                        abs(round(single_item.amount * adv_percentage / 100, 2))
                     )
 
                     tax_cat = ET.SubElement(subtotal, "cac:TaxCategory")
-                    zatca_tax_category = item_tax_template.custom_zatca_tax_category
+                    zatca_tax_category = adv_category
                     # Hold the category code in a local. This used to assign it to
                     # cbc_id_12, which is not a category element at all: it is the
                     # cac:TaxScheme/cbc:ID of the *last standard invoice line*,
@@ -1340,7 +1387,7 @@ def item_data_with_template_advance_invoice(invoice, sales_invoice_doc):
                     advance_tax_code = get_tax_code(zatca_tax_category)
                     ET.SubElement(tax_cat, "cbc:ID").text = advance_tax_code
                     ET.SubElement(tax_cat, "cbc:Percent").text = (
-                        f"{float(item_tax_percentage):.2f}"
+                        f"{float(adv_percentage):.2f}"
                     )
                     ET.SubElement(
                         ET.SubElement(tax_cat, "cac:TaxScheme"), "cbc:ID"
@@ -1355,7 +1402,7 @@ def item_data_with_template_advance_invoice(invoice, sales_invoice_doc):
                     )
                     ET.SubElement(tax_cat_adv, "cbc:ID").text = advance_tax_code
                     ET.SubElement(tax_cat_adv, "cbc:Percent").text = (
-                        f"{float(item_tax_percentage):.2f}"
+                        f"{float(adv_percentage):.2f}"
                     )
                     ET.SubElement(
                         ET.SubElement(tax_cat_adv, "cac:TaxScheme"), "cbc:ID"

--- a/zatca_erpgulf/zatca_erpgulf/doctype/zatca_multiple_setting/zatca_multiple_setting.js
+++ b/zatca_erpgulf/zatca_erpgulf/doctype/zatca_multiple_setting/zatca_multiple_setting.js
@@ -192,6 +192,15 @@ frappe.ui.form.on("ZATCA Multiple Setting", {
             return;
         }
 
+        // Without this the field is sent as undefined, frappe.call drops it from
+        // the payload entirely, and zatca_call_compliance fails server-side with a
+        // bare "missing 1 required positional argument: 'invoice_number'" that
+        // says nothing about which field was left empty.
+        if (!frm.doc.custom_sample_invoice_number_to_test) {
+            frappe.msgprint(__('Please set a Sample Invoice Number to test.'));
+            return;
+        }
+
         frappe.call({
             method: "frappe.client.get",
             args: {

--- a/zatca_erpgulf/zatca_erpgulf/sign_invoice.py
+++ b/zatca_erpgulf/zatca_erpgulf/sign_invoice.py
@@ -1046,6 +1046,20 @@ def zatca_call_compliance(
     """zatca call compliance"""
 
     try:
+        # frappe.call() omits keys whose value is undefined, so a caller that
+        # passes an empty "sample invoice number" field sends no invoice_number at
+        # all and this endpoint fails with an opaque
+        # "missing 1 required positional argument: 'invoice_number'" TypeError
+        # before any of the checks below run. Fail with something a user can act
+        # on instead.
+        if not invoice_number:
+            frappe.throw(
+                _(
+                    "Sample Invoice Number is required to run a compliance check. "
+                    "Set it on the form before pressing Check Compliance."
+                )
+            )
+
         if source_doc:
             source_doc = frappe.get_doc(json.loads(source_doc))
         company_name = frappe.db.get_value("Company", {"abbr": company_abbr}, "name")

--- a/zatca_erpgulf/zatca_erpgulf/xml_tax_data.py
+++ b/zatca_erpgulf/zatca_erpgulf/xml_tax_data.py
@@ -855,7 +855,17 @@ def tax_data_with_template(invoice, sales_invoice_doc):
                     advance.advance_amount
                     for advance in sales_invoice_doc.custom_advances_copy
                 )
-                payable_amount = round(tax_inclusive_amount - advance_amount, 2)
+                # advance_amount is a plain float: advance_amount is a Currency
+                # field on claudion4saudi's "advance sales invoice table", and
+                # frappe returns Currency values as floats. tax_inclusive_amount
+                # is a Decimal (quantized above), and Decimal - float raises
+                # TypeError, which this function catches and re-raises as
+                # "Data processing error in tax data template". Normalise before
+                # subtracting. The sibling in tax_data() is float-based today and
+                # so is unaffected, but the same guard would not hurt there.
+                payable_amount = round(
+                    tax_inclusive_amount - Decimal(str(advance_amount)), 2
+                )
 
         cbc_payableamount.text = str(payable_amount)
 


### PR DESCRIPTION
Two independent failures hit while integrating with `claudion4saudi` on Frappe/ERPNext v16 (frappe 16.32.0, erpnext 16.33.0, zatca_erpgulf 3.0.1). Both are small, and both were reproduced before being changed.

---

### 1. `Decimal - float` when an invoice carries an advance

Signing a Sales Invoice that has rows in `custom_advances_copy` fails with:

```
Data processing error in tax data template:
unsupported operand type(s) for -: 'decimal.Decimal' and 'float'
```

`xml_tax_data.py:858` subtracts `advance_amount` from `tax_inclusive_amount`. The left side is a `Decimal` (quantized a few lines above); the right side sums `advance.advance_amount`, a **Currency** field, which frappe returns as a `float`. The `except` block then re-raises it as the message above.

The branch only runs when `claudion4saudi` is installed **and** the invoice carries advances, which is likely why it hasn't surfaced before.

Fixed by normalising with `Decimal(str(...))` — safe for `float`, `int` and `Decimal` alike.

**Deliberately not changed:** the sibling at `xml_tax_data.py:469` has the identical shape but is not reachable in this state today — all three `tax_amount_without_retention` branches in `tax_data()` cast to `float`, so that subtraction is `float - float`. Patching it would change the emitted `cbc:PayableAmount` from `1000.0` to `1000.00` to fix a bug that doesn't exist yet, so it's flagged in a comment instead. Happy to include it if you'd rather have the symmetry.

### 2. Compliance check with an empty sample invoice number

Pressing **Check Compliance** on ZATCA Multiple Setting with *Sample Invoice Number to Test* empty gives:

```
TypeError: zatca_call_compliance() missing 1 required positional argument: 'invoice_number'
```

`zatca_multiple_setting.js:206` passes `"invoice_number": frm.doc.custom_sample_invoice_number_to_test`. `frappe.call()` drops keys whose value is `undefined`, so an empty field means the argument never reaches the server — the observed Form Dict contained only `compliance_type`, `company_abbr` and `source_doc` — and the endpoint fails on its first required positional before any of its own validation runs.

Guarded at both ends:

- **`sign_invoice.py`** rejects an empty `invoice_number` with a message naming the field. This is the one that matters, since it covers every caller rather than just this button.
- **`zatca_multiple_setting.js`** returns early with a `msgprint`, mirroring the `custom_linked_doctype` guard three lines above it.

Only `custom_check_compliance` needed the client-side guard — the other three handlers in that file (`custom_generate_final_csids`, `custom_generate_compliance_csid`, `custom_create_csr`) don't pass `invoice_number` at all.

### 3. `BR-CO-04` on any invoice that carries an advance

ZATCA refuses a Sales Invoice with an advance attached:

```
BR-CO-04: Each Invoice line (BG-25) shall be categorized with an Invoiced item
VAT category code (BT-151)
```

even though every line does carry a category code.

In `item_data_with_template_advance_invoice` the advance branch stores the category in `cbc_id_12`:

```python
if zatca_tax_category == "Standard":
    cbc_id_12.text = "S"
...
ET.SubElement(tax_cat, "cbc:ID").text = cbc_id_12.text
```

`cbc_id_12` is not a category element — it is the `cac:TaxScheme/cbc:ID` of the **last standard invoice line**, created and set to `"VAT"` at `create_xml_final_part.py:1221-1222`, still in scope only because it leaked out of the loop above. Assigning to it reaches back into an already-built line and rewrites `<cac:TaxScheme><cbc:ID>VAT</cbc:ID></cac:TaxScheme>` as `<cbc:ID>S</cbc:ID>`.

A `ClassifiedTaxCategory` is only identifiable as a VAT category through that scheme id, so the **standard** line loses its BT-151 and the invoice is refused. The advance line itself was always fine — it sets its own scheme to `"VAT"` a few lines later. With several items only the last standard line is corrupted.

Fixed by holding the code in a local via the existing `get_tax_code()` helper, so nothing already emitted is mutated.

**Left alone, flagged for you:** `item_tax_template` and `item_tax_percentage` are leaked loop variables in the same branch, so an advance line is described by the *last standard item's* tax template rather than its own, and a Sales Invoice with no standard lines would raise `NameError` there. Not part of this failure, so not touched — but worth a look.

---

### Verification

- `Decimal('1150.00') - 1150.0` reproduces the reported `TypeError`; the patched expression returns `Decimal('0.00')`. The cast was checked against `float`, `int`, `Decimal`, `0` and a fractional value.
- The BR-CO-04 fix was checked by modelling both invoice lines: **before**, line 1 serialises with scheme `"S"` and BT-151 becomes undiscoverable while line 2 is valid; **after**, both lines carry scheme `"VAT"` and a resolvable BT-151. The data was ruled out first — the Item Tax Template on the reporting site has `custom_zatca_tax_category = "Standard"` and rate 15.0, i.e. entirely correct.
- All three files compile / parse (`py_compile`, `node --check`).
- Branched from `main` at `afedb51`; the three touched files were byte-identical to `main` before patching.

I could not run a full ZATCA round-trip for the compliance guard — that needs onboarding credentials I don't have — so it's opened as a **draft**. Both changes are additive guards or a type cast, with no behaviour change on the paths that already work, but I'd rather you confirm against a real compliance run before it's marked ready.

Original context: the `Decimal` bug blocked every Sales Invoice with an attached Advance Sales Invoice on our site, and the compliance one blocked ZATCA onboarding.
